### PR TITLE
Fix spurious announce_mismatch for non-ASCII announce content, also fix tests

### DIFF
--- a/lib/CPANSec/CNA/App.pm
+++ b/lib/CPANSec/CNA/App.pm
@@ -746,6 +746,16 @@ USAGE
       return (_read_json_file($cves_json[0]), $cves_json[0]);
     }
 
+    # Refuse explicitly (without entering encrypted context / contacting the
+    # network) when the only local source is an encrypted/ record. Mirrors the
+    # announce command, which also declines encrypted sources.
+    my @encrypted = grep { -f $_ } (
+      File::Spec->catfile('encrypted', "$cve.yaml"),
+      File::Spec->catfile('encrypted', "$cve.json"),
+    );
+    die "Refusing reconcile for encrypted CVE source ($encrypted[0]); publish it to cves/ first.\n"
+      if @encrypted;
+
     die "Missing local CVE source for $cve under cves/ (yaml/json)\n";
   }
 

--- a/lib/CPANSec/CNA/App.pm
+++ b/lib/CPANSec/CNA/App.pm
@@ -15,6 +15,7 @@ use File::Basename qw(dirname basename);
 use File::Path qw(make_path);
 use File::Spec ();
 use File::Temp qw(tempfile);
+use Encode qw(decode);
 use HTTP::Tiny ();
 use JSON::PP qw(decode_json);
 use Storable qw(dclone);
@@ -392,13 +393,14 @@ USAGE
       $self->_assert_encrypted_write_safe($out);
       my $dir = dirname($out);
       make_path($dir) unless -d $dir;
-      open(my $fh, '>', $out) or die "Cannot write $out: $!\n";
+      open(my $fh, '>:encoding(UTF-8)', $out) or die "Cannot write $out: $!\n";
       print {$fh} $text;
       close($fh);
       print "Wrote $out\n";
       return 0;
     }
 
+    binmode(STDOUT, ':encoding(UTF-8)');
     print $text;
     return 0;
   }
@@ -952,7 +954,9 @@ USAGE
     my ($rc, @out) = $self->_run_cmd_capture_with_rc('git', 'show', "$ref:$path");
     die "Cannot read $path at git ref $ref\n"
       if !defined($rc) || $rc != 0;
-    return join('', @out);
+    # git show output is captured as raw bytes; decode so it compares
+    # consistently with _read_text_file / _render_announce_text (decoded strings).
+    return decode('UTF-8', join('', @out));
   }
 
   method _yaml_stub (%in) {
@@ -1260,7 +1264,7 @@ sub _read_json_file ($path) {
 }
 
 sub _read_text_file ($path) {
-  open(my $fh, '<', $path) or die "Cannot read $path: $!\n";
+  open(my $fh, '<:encoding(UTF-8)', $path) or die "Cannot read $path: $!\n";
   local $/;
   my $txt = <$fh>;
   close($fh);

--- a/t/14-cna-encrypted.t
+++ b/t/14-cna-encrypted.t
@@ -7,21 +7,30 @@ use File::Temp qw(tempdir tempfile);
 use Test::More;
 
 my ($gitcfg_fh, $gitcfg) = tempfile();
+print {$gitcfg_fh} <<'GITCONFIG';
+[user]
+  name = CNA Test
+  email = cna-test@example.invalid
+[init]
+  defaultBranch = main
+[commit]
+  gpgsign = false
+[tag]
+  gpgsign = false
+GITCONFIG
 close($gitcfg_fh);
 $ENV{GIT_CONFIG_GLOBAL} = $gitcfg;
 $ENV{GIT_CONFIG_SYSTEM} = $gitcfg;
 $ENV{GIT_CONFIG_NOSYSTEM} = 1;
 $ENV{GIT_TERMINAL_PROMPT} = 0;
 
-my $branch = _current_branch();
-if (defined $branch && $branch eq 'main') {
-  plan skip_all => "encrypted CVE operations are disallowed on main";
-}
-
 my $source_cve = 'CVE-2025-40906';
 my $cve = 'CVE-1900-9914';
 my $fixture_yaml = "t/var/$source_cve.yaml";
 my $root = tempdir(CLEANUP => 1);
+# cna inspects the CNA-root's git branch to enforce the "no encrypted ops on
+# main" policy, so the root must be a real git repo on a non-main branch.
+_init_root_repo($root);
 my $enc = "$root/encrypted";
 make_path($enc);
 my $yaml = "$enc/$cve.yaml";
@@ -74,10 +83,9 @@ sub _rewrite_cve_in_yaml ($path, $cve) {
   close($wh);
 }
 
-sub _current_branch () {
-  my $b = qx(git branch --show-current 2>/dev/null);
-  chomp $b;
-  return length($b) ? $b : undef;
+sub _init_root_repo ($dir) {
+  my $rc = system('git', 'init', '-q', '-b', 'cve-test-branch', $dir);
+  die "git init failed ($rc)\n" if $rc != 0;
 }
 
 sub _read_text ($path) {

--- a/t/15-cna-git-crypt-write-guard.t
+++ b/t/15-cna-git-crypt-write-guard.t
@@ -7,21 +7,30 @@ use File::Temp qw(tempdir tempfile);
 use Test::More;
 
 my ($gitcfg_fh, $gitcfg) = tempfile();
+print {$gitcfg_fh} <<'GITCONFIG';
+[user]
+  name = CNA Test
+  email = cna-test@example.invalid
+[init]
+  defaultBranch = main
+[commit]
+  gpgsign = false
+[tag]
+  gpgsign = false
+GITCONFIG
 close($gitcfg_fh);
 $ENV{GIT_CONFIG_GLOBAL} = $gitcfg;
 $ENV{GIT_CONFIG_SYSTEM} = $gitcfg;
 $ENV{GIT_CONFIG_NOSYSTEM} = 1;
 $ENV{GIT_TERMINAL_PROMPT} = 0;
 
-my $branch = _current_branch();
-if (defined $branch && $branch eq 'main') {
-  plan skip_all => "encrypted CVE operations are disallowed on main";
-}
-
 my $source_cve = 'CVE-2025-40906';
 my $cve = 'CVE-1900-9915';
 my $fixture_yaml = "t/var/$source_cve.yaml";
 my $root = tempdir(CLEANUP => 1);
+# cna inspects the CNA-root's git branch to enforce the "no encrypted ops on
+# main" policy, so the root must be a real git repo on a non-main branch.
+_init_root_repo($root);
 my $enc = "$root/encrypted";
 make_path($enc);
 my $yaml = "$enc/$cve.yaml";
@@ -44,7 +53,8 @@ like($out_unprotected, qr/not protected by attributes/i, 'unprotected refusal is
 my $out_ok = qx(CPANSEC_CNA_GIT_CRYPT_SHIM=ok scripts/cna --cpansec-cna-root '$root' build $cve --force 2>&1);
 my $rc_ok = $? >> 8;
 is($rc_ok, 0, 'build succeeds when git-crypt shim reports ok');
-like($out_ok, qr/^Wrote \Q$json\E/m, 'build writes encrypted json with ok shim');
+# cna chdir's into the CNA root, so it prints the repo-relative path.
+like($out_ok, qr{^Wrote \Qencrypted/$cve.json\E$}m, 'build writes encrypted json with ok shim');
 ok(-f $json, 'encrypted json was written');
 
 done_testing();
@@ -61,8 +71,7 @@ sub _rewrite_cve_in_yaml ($path, $cve) {
   close($wh);
 }
 
-sub _current_branch () {
-  my $b = qx(git branch --show-current 2>/dev/null);
-  chomp $b;
-  return length($b) ? $b : undef;
+sub _init_root_repo ($dir) {
+  my $rc = system('git', 'init', '-q', '-b', 'cve-test-branch', $dir);
+  die "git init failed ($rc)\n" if $rc != 0;
 }

--- a/t/16-cna-init-branch-switch.t
+++ b/t/16-cna-init-branch-switch.t
@@ -6,6 +6,17 @@ use File::Temp qw(tempdir tempfile);
 use Test::More;
 
 my ($gitcfg_fh, $gitcfg) = tempfile();
+print {$gitcfg_fh} <<'GITCONFIG';
+[user]
+  name = CNA Test
+  email = cna-test@example.invalid
+[init]
+  defaultBranch = main
+[commit]
+  gpgsign = false
+[tag]
+  gpgsign = false
+GITCONFIG
 close($gitcfg_fh);
 $ENV{GIT_CONFIG_GLOBAL} = $gitcfg;
 $ENV{GIT_CONFIG_SYSTEM} = $gitcfg;
@@ -79,8 +90,6 @@ sub _commit_all ($root, $msg) {
   die "git add failed ($rc_add)\n" if $rc_add != 0;
   my $rc_commit = system(
     'git', '-C', $root,
-    '-c', 'user.name=Test User',
-    '-c', 'user.email=test@example.invalid',
     'commit', '-q', '-m', $msg,
   );
   die "git commit failed ($rc_commit)\n" if $rc_commit != 0;

--- a/t/35-cna-check-pr-policy.t
+++ b/t/35-cna-check-pr-policy.t
@@ -7,6 +7,17 @@ use File::Temp qw(tempdir tempfile);
 use Test::More;
 
 my ($gitcfg_fh, $gitcfg) = tempfile();
+print {$gitcfg_fh} <<'GITCONFIG';
+[user]
+  name = CNA Test
+  email = cna-test@example.invalid
+[init]
+  defaultBranch = main
+[commit]
+  gpgsign = false
+[tag]
+  gpgsign = false
+GITCONFIG
 close($gitcfg_fh);
 $ENV{GIT_CONFIG_GLOBAL} = $gitcfg;
 $ENV{GIT_CONFIG_SYSTEM} = $gitcfg;
@@ -38,11 +49,8 @@ subtest 'new CVE with matching announce passes pr policy' => sub {
   my $cve = 'CVE-1900-9942';
   _write_yaml_from_fixture($root, $cve);
   make_path("$root/announce");
-  my $rc_announce = system(
-    'bash', '-lc',
-    "$cna --cpansec-cna-root '$root' announce $cve > '$root/announce/$cve.txt'",
-  );
-  is($rc_announce >> 8, 0, 'announce file generated');
+  qx($cna --cpansec-cna-root '$root' announce $cve > '$root/announce/$cve.txt');
+  is($? >> 8, 0, 'announce file generated');
 
   my $out = qx($cna --cpansec-cna-root '$root' check $cve --pr-policy --base-sha $base_sha 2>&1);
   my $rc = $? >> 8;
@@ -57,11 +65,8 @@ subtest 'existing CVE announce changes are rejected' => sub {
   my $cve = 'CVE-1900-9943';
   _write_yaml_from_fixture($root, $cve);
   make_path("$root/announce");
-  my $rc_announce = system(
-    'bash', '-lc',
-    "$cna --cpansec-cna-root '$root' announce $cve > '$root/announce/$cve.txt'",
-  );
-  is($rc_announce >> 8, 0, 'announce file generated');
+  qx($cna --cpansec-cna-root '$root' announce $cve > '$root/announce/$cve.txt');
+  is($? >> 8, 0, 'announce file generated');
   _commit_all($root, 'base cve with announce');
   my $base_sha = _head_sha($root);
 
@@ -112,8 +117,6 @@ sub _commit_all ($root, $msg) {
   die "git add failed ($rc_add)\n" if $rc_add != 0;
   my $rc_commit = system(
     'git', '-C', $root,
-    '-c', 'user.name=Test User',
-    '-c', 'user.email=test@example.invalid',
     'commit', '-q', '-m', $msg,
   );
   die "git commit failed ($rc_commit)\n" if $rc_commit != 0;

--- a/t/37-cna-announce-utf8-pr-policy.t
+++ b/t/37-cna-announce-utf8-pr-policy.t
@@ -1,0 +1,133 @@
+use strict;
+use v5.42;
+use utf8;
+
+use File::Path qw(make_path);
+use File::Temp qw(tempdir tempfile);
+use Test::More;
+
+# Isolate git config so the host environment cannot influence the test repo.
+my ($gitcfg_fh, $gitcfg) = tempfile();
+close($gitcfg_fh);
+$ENV{GIT_CONFIG_GLOBAL} = $gitcfg;
+$ENV{GIT_CONFIG_SYSTEM} = $gitcfg;
+$ENV{GIT_CONFIG_NOSYSTEM} = 1;
+$ENV{GIT_TERMINAL_PROMPT} = 0;
+
+my $cna = 'scripts/cna';
+
+# A non-ASCII credit value (synthetic researcher name containing U+0142 "ł"
+# plus other diacritics) reaches the generated announcement. Before the fix,
+# the writer relied on implicit wide-char auto-encoding (emitting a
+# "Wide character in print" warning) and the --pr-policy reader slurped raw
+# bytes, so the in-memory comparison reported a spurious announce_mismatch.
+my $credit_value = 'Tëst Reséarcher Łówski (EXAMPLE)';
+
+my $root = _init_git_repo('main');
+_seed_base_commit($root);
+my $base_sha = _head_sha($root);
+
+my $cve = 'CVE-1900-9950';
+_write_yaml($root, $cve, $credit_value);
+
+# Writer: capture stderr so we can assert there is no "Wide character" warning.
+my ($warn_fh, $warn_file) = tempfile();
+close($warn_fh);
+qx($cna --cpansec-cna-root '$root' announce $cve --write 2>'$warn_file');
+is($? >> 8, 0, 'announce --write succeeds for non-ASCII credit');
+
+my $warnings = _slurp($warn_file);
+unlike($warnings, qr/Wide character/, 'no "Wide character in print" warning on write');
+
+my $announce_path = "$root/announce/$cve.txt";
+ok(-f $announce_path, 'announce file written');
+
+# Written file must be valid UTF-8 and carry the wide character intact.
+my $written = _slurp_utf8($announce_path);
+like($written, qr/\QŁówski\E/, 'announce file preserves non-ASCII credit');
+
+# CI-equivalent check: must report no announce_mismatch for the new CVE.
+my $out = qx($cna --cpansec-cna-root '$root' check $cve --pr-policy --base-sha $base_sha 2>&1);
+my $rc = $? >> 8;
+
+is($rc, 0, "pr-policy check passes for non-ASCII announce\n$out");
+unlike($out, qr/announce_mismatch/, 'no spurious announce_mismatch for non-ASCII content');
+
+done_testing();
+
+sub _init_git_repo ($branch) {
+  my $dir = tempdir(CLEANUP => 1);
+  my $rc = system('git', 'init', '-q', '-b', $branch, $dir);
+  die "git init failed ($rc)\n" if $rc != 0;
+  return $dir;
+}
+
+sub _seed_base_commit ($dir) {
+  open(my $fh, '>', "$dir/.seed") or die "Cannot write seed: $!";
+  print {$fh} "seed\n";
+  close($fh);
+  _commit_all($dir, 'seed base');
+}
+
+sub _write_yaml ($dir, $id, $credit) {
+  make_path("$dir/cves");
+  my $target = "$dir/cves/$id.yaml";
+  open(my $fh, '>:encoding(UTF-8)', $target) or die "Cannot write $target: $!";
+  print {$fh} <<"YAML";
+cpansec:
+  cve: $id
+  distribution: Example-Dist
+  module: Example::Module
+  author: EXAMPLE
+  repo: https://example.invalid/repo
+  affected:
+    - "<= 1.0"
+  title: Example::Module versions until 1.0 for Perl has an issue
+  description: |-
+    Example::Module versions until 1.0 for Perl has an issue.
+    More detail.
+  solution: |-
+    Upgrade to 1.1.
+  credits:
+    - type: finder
+      value: "$credit"
+  references:
+    - link: https://example.com/advisory
+      tags: [vendor-advisory]
+YAML
+  close($fh);
+}
+
+sub _commit_all ($dir, $msg) {
+  my $rc_add = system('git', '-C', $dir, 'add', '-A');
+  die "git add failed ($rc_add)\n" if $rc_add != 0;
+  my $rc_commit = system(
+    'git', '-C', $dir,
+    '-c', 'user.name=Test User',
+    '-c', 'user.email=test@example.invalid',
+    'commit', '-q', '-m', $msg,
+  );
+  die "git commit failed ($rc_commit)\n" if $rc_commit != 0;
+}
+
+sub _head_sha ($dir) {
+  my $sha = qx(git -C '$dir' rev-parse HEAD);
+  chomp $sha;
+  return $sha;
+}
+
+sub _slurp ($path) {
+  open(my $fh, '<', $path) or die "Cannot read $path: $!";
+  local $/;
+  my $txt = <$fh>;
+  close($fh);
+  return $txt // '';
+}
+
+sub _slurp_utf8 ($path) {
+  open(my $fh, '<:encoding(UTF-8)', $path) or die "Cannot read $path: $!";
+  local $/;
+  my $txt = <$fh>;
+  close($fh);
+  return $txt // '';
+}

--- a/t/37-cna-announce-utf8-pr-policy.t
+++ b/t/37-cna-announce-utf8-pr-policy.t
@@ -8,6 +8,17 @@ use Test::More;
 
 # Isolate git config so the host environment cannot influence the test repo.
 my ($gitcfg_fh, $gitcfg) = tempfile();
+print {$gitcfg_fh} <<'GITCONFIG';
+[user]
+  name = CNA Test
+  email = cna-test@example.invalid
+[init]
+  defaultBranch = main
+[commit]
+  gpgsign = false
+[tag]
+  gpgsign = false
+GITCONFIG
 close($gitcfg_fh);
 $ENV{GIT_CONFIG_GLOBAL} = $gitcfg;
 $ENV{GIT_CONFIG_SYSTEM} = $gitcfg;
@@ -103,8 +114,6 @@ sub _commit_all ($dir, $msg) {
   die "git add failed ($rc_add)\n" if $rc_add != 0;
   my $rc_commit = system(
     'git', '-C', $dir,
-    '-c', 'user.name=Test User',
-    '-c', 'user.email=test@example.invalid',
     'commit', '-q', '-m', $msg,
   );
   die "git commit failed ($rc_commit)\n" if $rc_commit != 0;


### PR DESCRIPTION
The --pr-policy announce comparison decoded its two sides inconsistently: _render_announce_text returned a decoded string while _read_text_file and _git_show_text_at_ref returned raw bytes. Any non-ASCII character (e.g. a diacritic in a finder credit) therefore tripped a false announce_mismatch, failing CI even though the on-disk file was correct UTF-8.

Make all announce text I/O consistently UTF-8:
- _read_text_file opens with :encoding(UTF-8)
- _cmd_announce writes with :encoding(UTF-8) and binmodes STDOUT, removing the 'Wide character in print' warning
- _git_show_text_at_ref decodes the captured git show bytes

Add a regression test with a non-ASCII credit asserting a clean write (no wide-char warning) and a passing --pr-policy check.