### PR TITLE
Fix spurious announce_wording_mismatch for perl interpreter core

### DIFF
--- a/lib/CPANSec/CNA/Lint.pm
+++ b/lib/CPANSec/CNA/Lint.pm
@@ -164,6 +164,15 @@ sub _expected_announce_lead ($cpansec) {
   my $phrase = template_version_range_from_affected($cpansec->{affected});
   return '' unless length $phrase;
 
+  # The Perl interpreter core (distribution and module both 'perl') follows the
+  # 'Perl <version range> ...' convention rather than the '<module> <version
+  # range> for Perl ...' form used for CPAN distributions. Appending 'for Perl'
+  # there would read as a doubled 'perl ... for Perl'.
+  my $distribution = _normalize_inline($cpansec->{distribution} // '');
+  if (lc($distribution) eq 'perl' && lc($module) eq 'perl') {
+    return "Perl $phrase";
+  }
+
   return "$module $phrase for Perl";
 }
 

--- a/t/06-cna-lint.t
+++ b/t/06-cna-lint.t
@@ -50,6 +50,51 @@ my @metacpan_changelog_cases = (
   { url => 'https://metacpan.org/release/DDICK/Crypt-URandom-0.55/source/Changes', expect_warn => 0 },
 );
 
+# Regression: the perl interpreter core (distribution and module both 'perl')
+# uses the 'Perl <version range> have ...' wording, not '<module> ... for Perl'.
+# The announce wording lint must accept that form and not warn.
+my $perl_core_model = CPANSec::CVE::Model->new(
+  cpansec => {
+    cve => 'CVE-1900-9998',
+    distribution => 'perl',
+    module => 'perl',
+    author => 'AUTHOR',
+    affected => ['<= 5.43.10'],
+    title => 'Perl versions through 5.43.10 have a buffer overflow',
+    description => "Perl versions through 5.43.10 have a buffer overflow.\n\nMore details.",
+    solution => 'Update to a fixed release.',
+    references => [ { link => 'https://example.invalid/TODO', tags => ['advisory'] } ],
+  },
+);
+my $perl_core_findings = $lint->run_model($perl_core_model, path => 't/var/CVE-1900-9998.yaml');
+my %perl_core_by_id = map { ($_->{id} => $_) } @$perl_core_findings;
+ok(
+  !$perl_core_by_id{announce_wording_mismatch},
+  'no announce_wording_mismatch for perl core record using "Perl <range> have ..." wording',
+);
+
+# A perl core record whose lead text genuinely diverges from the version
+# phrasing should still warn.
+my $perl_core_bad_model = CPANSec::CVE::Model->new(
+  cpansec => {
+    cve => 'CVE-1900-9997',
+    distribution => 'perl',
+    module => 'perl',
+    author => 'AUTHOR',
+    affected => ['<= 5.43.10'],
+    title => 'A buffer overflow affects the interpreter',
+    description => "A buffer overflow affects the interpreter.\n\nMore details.",
+    solution => 'Update to a fixed release.',
+    references => [ { link => 'https://example.invalid/TODO', tags => ['advisory'] } ],
+  },
+);
+my $perl_core_bad_findings = $lint->run_model($perl_core_bad_model, path => 't/var/CVE-1900-9997.yaml');
+my %perl_core_bad_by_id = map { ($_->{id} => $_) } @$perl_core_bad_findings;
+ok(
+  $perl_core_bad_by_id{announce_wording_mismatch},
+  'still warns for perl core record whose lead text does not match version phrasing',
+);
+
 for my $i (0 .. $#metacpan_changelog_cases) {
   my $case = $metacpan_changelog_cases[$i];
   my $case_model = CPANSec::CVE::Model->new(


### PR DESCRIPTION
The announce wording lint built the expected title lead as "<module> <version range> for Perl". For the Perl interpreter core (distribution and module both 'perl'), the corpus convention is "Perl <version range> ..." with no trailing "for Perl", so the lint warned on every perl-core record.

Special-case distribution == module == 'perl' to expect the "Perl <version range>" lead instead. The announce renderer emits the title verbatim, so no renderer change is needed.

Add regression tests: a perl-core record using the "Perl <range> have ..." wording asserts no announce_wording_mismatch, and a perl-core record whose lead genuinely diverges still warns.